### PR TITLE
chore(docker): update n8n and Temporal service dependencies in production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,7 @@
 services:
   n8n:
-    depends_on: !reset null
+    depends_on: 
+      postgresql: !reset null
     environment:
       - WEBHOOK_URL=${N8N_WEBHOOK_URL:?N8N_WEBHOOK_URL is required}
       - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY:?N8N_ENCRYPTION_KEY is required}
@@ -10,14 +11,12 @@ services:
       - DB_POSTGRESDB_DATABASE=${POSTGRES_DB_N8N:?POSTGRES_DB_N8N is required}
       - DB_POSTGRESDB_USER=${POSTGRES_USER_N8N:?POSTGRES_USER_N8N is required}
       - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD_N8N:?POSTGRES_PASSWORD_N8N is required}
-  opensearch:
-    environment:
-      - OPENSEARCH_PORT=${OPENSEARCH_PORT:?OPENSEARCH_PORT is required}
 
   postgresql: !reset null
 
   temporal:
-    depends_on: !reset null
+    depends_on:
+      postgresql: !reset null
     environment:
       - TEMPORAL_PORT=${TEMPORAL_PORT:?TEMPORAL_PORT is required}
       - POSTGRES_SEEDS=${POSTGRES_HOST:?POSTGRES_HOST is required}
@@ -25,10 +24,6 @@ services:
       - DBNAME=${POSTGRES_DB_TEMPORAL:?POSTGRES_DB_TEMPORAL is required}
       - POSTGRES_USER=${POSTGRES_USER_TEMPORAL:?POSTGRES_USER_TEMPORAL is required}
       - POSTGRES_PWD=${POSTGRES_PASSWORD_TEMPORAL:?POSTGRES_PASSWORD_TEMPORAL is required}
-      - ES_SEEDS=opensearch
-      - ES_VERSION=v7
-      - DB=postgresql
-      - ENABLE_ES=true
 
   temporal-ui:
     environment:
@@ -107,9 +102,3 @@ volumes:
       type: none
       o: bind
       device: /data/n8n
-  opensearch-data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /data/opensearch


### PR DESCRIPTION
- Removed PostgreSQL dependency for both n8n and Temporal services in `docker-compose.prod.yml`.
- Removed the OpenSearch service configuration to streamline the setup further.

These changes enhance the reliability of service dependencies in the production environment.