### PR TITLE
feat(docker): add timezone configuration for n8n in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD_N8N:-n8n_password}
       - N8N_LOG_LEVEL=debug
       - N8N_LOG_OUTPUT=console
+      - TZ=${TZ:-America/New_York}
     volumes:
       - n8n_data:/home/node/.n8n
     networks:


### PR DESCRIPTION
- Added a new environment variable for timezone (TZ) in the docker-compose.yml file to allow for timezone customization for the n8n service.

This change enhances the n8n service by enabling users to set their preferred timezone, improving scheduling and time-related functionalities.