### PR TITLE
feat(docker): add blocked nodes configuration for n8n in production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@ services:
       - N8N_SMTP_SENDER=${N8N_SMTP_SENDER:?N8N_SMTP_SENDER is required}
       - N8N_SMTP_SSL=${N8N_SMTP_SSL:-false}
       - N8N_SMTP_TLS=${N8N_SMTP_TLS:-true}
-
+      - N8N_BLOCKED_NODES=n8n-nodes-base.executeCommand,n8n-nodes-base.ssh
   postgresql: !reset null
 
   temporal:


### PR DESCRIPTION
- Introduced a new environment variable `N8N_BLOCKED_NODES` in the `docker-compose.prod.yml` file to specify blocked nodes for the n8n service.

This change enhances the n8n service by allowing users to restrict certain nodes, improving security and control over workflows.