### PR TITLE
chore: Add CODEOWNERS file with default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS file
+#
+# This file is used to define the owners of code in this repository.
+# The owners will be automatically requested for review when someone opens a PR.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo
+* @killev 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo
-* @killev 
+* @killev


### PR DESCRIPTION
- Add CODEOWNERS file to automatically assign @killev as default reviewer
- Configure repository to follow GitHub's code ownership rules

This change helps streamline the review process by automatically requesting review from the designated code owner when PRs are opened.
