### PR TITLE
Implement FileUtilsError class with unit tests

### DIFF
--- a/workers/main/src/common/errors/FileUtilsError.test.ts
+++ b/workers/main/src/common/errors/FileUtilsError.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { FileUtilsError } from './FileUtilsError';
+
+describe('FileUtilsError', () => {
+  it('should set the message and name', () => {
+    const err = new FileUtilsError('test message');
+
+    expect(err.message).toBe('test message');
+    expect(err.name).toBe('FileUtilsError');
+  });
+
+  it('should set the cause if provided', () => {
+    const cause = new Error('root cause');
+    const err = new FileUtilsError('with cause', cause);
+
+    expect(err.cause).toBe(cause);
+  });
+
+  it('should not set cause if not provided', () => {
+    const err = new FileUtilsError('no cause');
+
+    expect(err.cause).toBeUndefined();
+  });
+});

--- a/workers/main/src/common/errors/FileUtilsError.ts
+++ b/workers/main/src/common/errors/FileUtilsError.ts
@@ -1,0 +1,9 @@
+export class FileUtilsError extends Error {
+  public cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'FileUtilsError';
+    this.cause = cause;
+  }
+}

--- a/workers/main/src/common/errors/index.ts
+++ b/workers/main/src/common/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './FileUtilsError';


### PR DESCRIPTION
- Added `FileUtilsError.ts` to define a custom error class for file-related operations, including optional cause handling.
- Created `FileUtilsError.test.ts` to validate the functionality of the `FileUtilsError` class, ensuring proper message, name, and cause assignment.

These additions enhance error handling for file operations and improve test coverage for error management.