### PR TITLE
Refactor error classes.

### DIFF
--- a/workers/main/src/common/errors/AppError.ts
+++ b/workers/main/src/common/errors/AppError.ts
@@ -1,0 +1,9 @@
+export class AppError extends Error {
+  constructor(message: string, name: string) {
+    super(message);
+    this.name = name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/workers/main/src/common/errors/FileUtilsError.test.ts
+++ b/workers/main/src/common/errors/FileUtilsError.test.ts
@@ -9,17 +9,4 @@ describe('FileUtilsError', () => {
     expect(err.message).toBe('test message');
     expect(err.name).toBe('FileUtilsError');
   });
-
-  it('should set the cause if provided', () => {
-    const cause = new Error('root cause');
-    const err = new FileUtilsError('with cause', cause);
-
-    expect(err.cause).toBe(cause);
-  });
-
-  it('should not set cause if not provided', () => {
-    const err = new FileUtilsError('no cause');
-
-    expect(err.cause).toBeUndefined();
-  });
 });

--- a/workers/main/src/common/errors/FileUtilsError.ts
+++ b/workers/main/src/common/errors/FileUtilsError.ts
@@ -1,12 +1,7 @@
-export class FileUtilsError extends Error {
-  public cause?: unknown;
+import { AppError } from './AppError';
 
-  constructor(message: string, cause?: unknown) {
-    super(message);
-    this.name = 'FileUtilsError';
-    this.cause = cause;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, FileUtilsError);
-    }
+export class FileUtilsError extends AppError {
+  constructor(message: string) {
+    super(message, 'FileUtilsError');
   }
 }

--- a/workers/main/src/common/errors/TargetUnitRepositoryError.test.ts
+++ b/workers/main/src/common/errors/TargetUnitRepositoryError.test.ts
@@ -9,17 +9,4 @@ describe('TargetUnitRepositoryError', () => {
     expect(err.message).toBe('test message');
     expect(err.name).toBe('TargetUnitRepositoryError');
   });
-
-  it('should set the cause if provided', () => {
-    const cause = new Error('root cause');
-    const err = new TargetUnitRepositoryError('with cause', cause);
-
-    expect(err.cause).toBe(cause);
-  });
-
-  it('should not set cause if not provided', () => {
-    const err = new TargetUnitRepositoryError('no cause');
-
-    expect(err.cause).toBeUndefined();
-  });
 });

--- a/workers/main/src/common/errors/TargetUnitRepositoryError.ts
+++ b/workers/main/src/common/errors/TargetUnitRepositoryError.ts
@@ -1,12 +1,7 @@
-export class TargetUnitRepositoryError extends Error {
-  public cause?: unknown;
+import { AppError } from './AppError';
 
-  constructor(message: string, cause?: unknown) {
-    super(message);
-    this.name = 'TargetUnitRepositoryError';
-    this.cause = cause;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, TargetUnitRepositoryError);
-    }
+export class TargetUnitRepositoryError extends AppError {
+  constructor(message: string) {
+    super(message, 'TargetUnitRepositoryError');
   }
 }

--- a/workers/main/src/common/errors/index.ts
+++ b/workers/main/src/common/errors/index.ts
@@ -1,2 +1,3 @@
+export * from './AppError';
 export * from './FileUtilsError';
 export * from './TargetUnitRepositoryError';


### PR DESCRIPTION
Introduced a new base class `AppError` to standardize error handling. Updated `FileUtilsError` and `TargetUnitRepositoryError` to derive from `AppError`, simplifying their structure and removing redundant code. Removed tests for deprecated error properties (`cause`), aligning with the new error design.