### PR TITLE
Add file utility functions with unit tests

### DIFF
--- a/workers/main/src/common/fileUtils.test.ts
+++ b/workers/main/src/common/fileUtils.test.ts
@@ -1,0 +1,92 @@
+vi.mock('fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+  },
+}));
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { FileUtilsError } from './errors';
+import { readJsonFile, writeJsonFile } from './fileUtils';
+
+describe('fileUtils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readJsonFile', () => {
+    test('reads and parses JSON file', async () => {
+      vi.mocked(fs.readFile).mockResolvedValueOnce('{"a":1}');
+      const result = await readJsonFile<{ a: number }>('test.json');
+
+      expect(result).toEqual({ a: 1 });
+      expect(fs.readFile).toHaveBeenCalledWith('test.json', 'utf-8');
+    });
+
+    test('throws FileUtilsError for invalid path', async () => {
+      await expect(readJsonFile('')).rejects.toBeInstanceOf(FileUtilsError);
+    });
+
+    test('throws FileUtilsError for invalid JSON', async () => {
+      vi.mocked(fs.readFile).mockResolvedValueOnce('not-json');
+      await expect(readJsonFile('bad.json')).rejects.toBeInstanceOf(
+        FileUtilsError,
+      );
+    });
+
+    test('throws FileUtilsError if fs.readFile throws', async () => {
+      vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('fail'));
+      await expect(readJsonFile('fail.json')).rejects.toBeInstanceOf(
+        FileUtilsError,
+      );
+    });
+  });
+
+  describe('writeJsonFile', () => {
+    test('writes JSON file and creates directory', async () => {
+      vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValueOnce(undefined);
+      const filePath = 'dir/file.json';
+      const data = { b: 2 };
+
+      await writeJsonFile(filePath, data);
+      expect(fs.mkdir).toHaveBeenCalledWith(path.dirname(filePath), {
+        recursive: true,
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        filePath,
+        JSON.stringify(data, null, 2),
+        'utf-8',
+      );
+    });
+
+    test('throws FileUtilsError for invalid path', async () => {
+      await expect(writeJsonFile('', {})).rejects.toBeInstanceOf(
+        FileUtilsError,
+      );
+    });
+
+    test('throws FileUtilsError if fs.mkdir throws', async () => {
+      vi.mocked(fs.mkdir).mockRejectedValueOnce(new Error('fail'));
+      await expect(writeJsonFile('fail.json', {})).rejects.toBeInstanceOf(
+        FileUtilsError,
+      );
+    });
+
+    test('throws FileUtilsError if fs.writeFile throws', async () => {
+      vi.mocked(fs.mkdir).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.writeFile).mockRejectedValueOnce(new Error('fail'));
+      await expect(writeJsonFile('fail2.json', {})).rejects.toBeInstanceOf(
+        FileUtilsError,
+      );
+    });
+  });
+});

--- a/workers/main/src/common/fileUtils.ts
+++ b/workers/main/src/common/fileUtils.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { FileUtilsError } from './errors';
+
+export async function readJsonFile<T = unknown>(filePath: string): Promise<T> {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new FileUtilsError('Invalid file path provided to readJsonFile');
+  }
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+
+    return JSON.parse(content) as T;
+  } catch {
+    throw new FileUtilsError(
+      `Failed to read or parse JSON file at "${filePath}"`,
+    );
+  }
+}
+
+export async function writeJsonFile<T = object>(
+  filePath: string,
+  data: T,
+): Promise<void> {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new FileUtilsError('Invalid file path provided to writeJsonFile');
+  }
+  try {
+    const dir = path.dirname(filePath);
+
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  } catch {
+    throw new FileUtilsError(`Failed to write JSON file at "${filePath}"`);
+  }
+}


### PR DESCRIPTION
- Introduced `fileUtils.ts` containing `readJsonFile` and `writeJsonFile` functions for reading and writing JSON files, respectively.
- Implemented error handling using `FileUtilsError` for invalid paths and file operation failures.
- Created `fileUtils.test.ts` to validate the functionality of the file utility functions, ensuring proper error handling and file operations.

These additions enhance file management capabilities and improve test coverage for file-related operations.