### PR TITLE
Add FinAppRepositoryError class with unit tests

### DIFF
--- a/workers/main/src/common/errors/FinAppRepositoryError.test.ts
+++ b/workers/main/src/common/errors/FinAppRepositoryError.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { FinAppRepositoryError } from './FinAppRepositoryError';
+
+describe('FinAppRepositoryError', () => {
+  it('should set the message and name', () => {
+    const err = new FinAppRepositoryError('test message');
+
+    expect(err.message).toBe('test message');
+    expect(err.name).toBe('FinAppRepositoryError');
+  });
+});

--- a/workers/main/src/common/errors/FinAppRepositoryError.ts
+++ b/workers/main/src/common/errors/FinAppRepositoryError.ts
@@ -1,0 +1,7 @@
+import { AppError } from './AppError';
+
+export class FinAppRepositoryError extends AppError {
+  constructor(message: string) {
+    super(message, 'FinAppRepositoryError');
+  }
+}

--- a/workers/main/src/common/errors/index.ts
+++ b/workers/main/src/common/errors/index.ts
@@ -1,3 +1,4 @@
 export * from './AppError';
 export * from './FileUtilsError';
+export * from './FinAppRepositoryError';
 export * from './TargetUnitRepositoryError';


### PR DESCRIPTION
- Introduced `FinAppRepositoryError` class extending `AppError` to standardize error handling for financial application repository errors.
- Created `FinAppRepositoryError.test.ts` to validate the functionality of the new error class, ensuring proper message and name assignment.
- Updated the index file to export the new error class.

These additions enhance error management for the financial application and improve test coverage for error handling.