### PR TITLE
Add QuickBooksRepositoryError class and corresponding tests

### DIFF
--- a/workers/main/src/common/errors/QuickBooksError.test.ts
+++ b/workers/main/src/common/errors/QuickBooksError.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { QuickBooksRepositoryError } from './QuickBooksRepositoryError';
+
+describe('QuickBooksRepositoryError', () => {
+  it('should set the message and name', () => {
+    const err = new QuickBooksRepositoryError('test message');
+
+    expect(err.message).toBe('test message');
+    expect(err.name).toBe('QuickBooksRepositoryError');
+  });
+});

--- a/workers/main/src/common/errors/QuickBooksRepositoryError.ts
+++ b/workers/main/src/common/errors/QuickBooksRepositoryError.ts
@@ -1,0 +1,7 @@
+import { AppError } from './AppError';
+
+export class QuickBooksRepositoryError extends AppError {
+  constructor(message: string) {
+    super(message, 'QuickBooksRepositoryError');
+  }
+}

--- a/workers/main/src/common/errors/index.ts
+++ b/workers/main/src/common/errors/index.ts
@@ -1,3 +1,4 @@
 export * from './AppError';
 export * from './FileUtilsError';
+export * from './QuickBooksRepositoryError';
 export * from './TargetUnitRepositoryError';


### PR DESCRIPTION
- Introduced `QuickBooksRepositoryError` class extending `AppError` for standardized error handling related to QuickBooks operations.
- Updated `index.ts` to export the new error class.
- Created unit tests for `QuickBooksRepositoryError` to validate message and name assignment.

These changes enhance error management for QuickBooks integration and improve test coverage for error handling.