### PR TITLE
Add FinApp repository with employee and project data access methods

### DIFF
--- a/workers/main/src/services/FinApp/FinAppRepository.test.ts
+++ b/workers/main/src/services/FinApp/FinAppRepository.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FinAppRepository } from './FinAppRepository';
+import { FinAppRepositoryError } from '../../common/errors';
+import { EmployeeModel, ProjectModel } from './FinAppSchemas';
+import type { Employee, Project } from './types';
+
+vi.mock('./FinAppSchemas', () => {
+  return {
+    EmployeeModel: {
+      find: vi.fn(),
+    },
+    ProjectModel: {
+      find: vi.fn(),
+    },
+  };
+});
+
+describe('FinAppRepository', () => {
+  let repo: FinAppRepository;
+
+  beforeEach(() => {
+    repo = new FinAppRepository();
+    vi.clearAllMocks();
+  });
+
+  describe('getEmployees', () => {
+    it('returns employees on success', async () => {
+      const employees: Employee[] = [
+        { redmine_id: 1, history: { rate: { '2024-01-01': 100 } } },
+      ];
+      (EmployeeModel.find as any).mockReturnValueOnce({
+        lean: vi.fn().mockResolvedValueOnce(employees),
+      });
+      const result = await repo.getEmployees([1]);
+      expect(result).toEqual(employees);
+      expect(EmployeeModel.find).toHaveBeenCalledWith(
+        { redmine_id: { $in: [1] } },
+        { redmine_id: 1, 'history.rate': 1 },
+      );
+    });
+
+    it('throws FinAppRepositoryError on error', async () => {
+      (EmployeeModel.find as any).mockImplementationOnce(() => {
+        throw new Error('fail');
+      });
+      await expect(repo.getEmployees([1])).rejects.toThrow(FinAppRepositoryError);
+    });
+  });
+
+  describe('getProjects', () => {
+    it('returns projects on success', async () => {
+      const projects: Project[] = [
+        { redmine_id: 2, quick_books_id: 10, history: { rate: { '2024-01-01': 200 } } },
+      ];
+      (ProjectModel.find as any).mockReturnValueOnce({
+        lean: vi.fn().mockResolvedValueOnce(projects),
+      });
+      const result = await repo.getProjects([2]);
+      expect(result).toEqual(projects);
+      expect(ProjectModel.find).toHaveBeenCalledWith(
+        { redmine_id: { $in: [2] } },
+        { redmine_id: 1, quick_books_id: 1, 'history.rate': 1 },
+      );
+    });
+
+    it('throws FinAppRepositoryError on error', async () => {
+      (ProjectModel.find as any).mockImplementationOnce(() => {
+        throw new Error('fail');
+      });
+      await expect(repo.getProjects([2])).rejects.toThrow(FinAppRepositoryError);
+    });
+  });
+}); 

--- a/workers/main/src/services/FinApp/FinAppRepository.ts
+++ b/workers/main/src/services/FinApp/FinAppRepository.ts
@@ -1,0 +1,49 @@
+import { FinAppRepositoryError } from '../../common/errors';
+import { EmployeeModel, ProjectModel } from './FinAppSchemas';
+import { IFinAppRepository } from './IFinAppRepository';
+import { Employee, Project } from './types';
+import { Model, Document } from 'mongoose';
+
+/**
+ * Repository for accessing FinApp employee and project data.
+ */
+export class FinAppRepository implements IFinAppRepository {
+  /**
+   * Generic private method to find documents by redmine_id.
+   * @param model Mongoose model
+   * @param ids Array of redmine IDs
+   * @param projection Fields to project
+   * @returns Promise resolving to array of documents
+   */
+  private async _findByIds<T>(model: Model<T & Document>, ids: number[], projection: Record<string, any>): Promise<T[]> {
+    try {
+      return await model.find(
+          { redmine_id: { $in: ids } },
+          projection,
+      ).lean<T[]>();
+    } catch (error) {
+      throw new FinAppRepositoryError(
+          `FinAppRepository._findByIds failed: ${(error as Error).message} (ids: ${ids})`,
+      );
+    }
+  }
+  /**
+   * Fetch employees by Redmine user IDs.
+   * @param userIds Array of Redmine user IDs
+   * @returns Promise resolving to array of Employee objects
+   */
+  async getEmployees(userIds: number[]): Promise<Employee[]> {
+    return this._findByIds(EmployeeModel, userIds, { redmine_id: 1, 'history.rate': 1 });
+  }
+
+  /**
+   * Fetch projects by Redmine project IDs.
+   * @param projectIds Array of Redmine project IDs
+   * @returns Promise resolving to array of Project objects
+   */
+  async getProjects(projectIds: number[]): Promise<Project[]> {
+    return this._findByIds(ProjectModel, projectIds, { redmine_id: 1, quick_books_id: 1, 'history.rate': 1 });
+  }
+
+
+}

--- a/workers/main/src/services/FinApp/FinAppSchemas.ts
+++ b/workers/main/src/services/FinApp/FinAppSchemas.ts
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose';
+
+export const historySchema = new mongoose.Schema(
+  {
+    rate: { type: Map, of: Number },
+  },
+  { _id: false },
+);
+
+export const employeeSchema = new mongoose.Schema({
+  redmine_id: { type: Number, required: true, index: true },
+  history: historySchema,
+});
+
+export const EmployeeModel =
+  mongoose.models.Employee || mongoose.model('Employee', employeeSchema);
+
+export const projectSchema = new mongoose.Schema({
+  redmine_id: { type: Number, required: true, index: true },
+  quick_books_id: Number,
+  history: historySchema,
+});
+
+export const ProjectModel =
+  mongoose.models.Project || mongoose.model('Project', projectSchema);

--- a/workers/main/src/services/FinApp/IFinAppRepository.ts
+++ b/workers/main/src/services/FinApp/IFinAppRepository.ts
@@ -1,0 +1,15 @@
+import { Employee, Project } from './types';
+
+/**
+ * Interface for FinApp repository operations.
+ */
+export interface IFinAppRepository {
+  /**
+   * Fetch employees by Redmine user IDs.
+   */
+  getEmployees(userIds: number[]): Promise<Employee[]>;
+  /**
+   * Fetch projects by Redmine project IDs.
+   */
+  getProjects(projectIds: number[]): Promise<Project[]>;
+}

--- a/workers/main/src/services/FinApp/index.ts
+++ b/workers/main/src/services/FinApp/index.ts
@@ -1,0 +1,4 @@
+export * from './FinAppRepository';
+export * from './IFinAppRepository';
+export * from './FinAppSchemas';
+export * from './types'; 

--- a/workers/main/src/services/FinApp/types.ts
+++ b/workers/main/src/services/FinApp/types.ts
@@ -1,0 +1,14 @@
+export interface History {
+  rate: { [date: string]: number };
+}
+
+export interface Employee {
+  redmine_id: number;
+  history?: History;
+}
+
+export interface Project {
+  redmine_id: number;
+  quick_books_id?: number;
+  history?: History;
+}


### PR DESCRIPTION
- Introduced `FinAppRepository` class for managing employee and project data retrieval.
- Implemented methods `getEmployees` and `getProjects` to fetch data by Redmine IDs, with error handling using `FinAppRepositoryError`.
- Created corresponding unit tests in `FinAppRepository.test.ts` to validate functionality and error handling.
- Added Mongoose schemas for `Employee` and `Project` models in `FinAppSchemas.ts`.

These additions enhance data management capabilities for the financial application and improve test coverage for repository operations.