### PR TITLE
Refactor getTargetUnits to accept group name parameter

### DIFF
--- a/workers/main/src/activities/weeklyFinancialReports/getTargetUnits.test.ts
+++ b/workers/main/src/activities/weeklyFinancialReports/getTargetUnits.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { AppError } from '../../common/errors';
 import { writeJsonFile } from '../../common/fileUtils';
 import { RedminePool } from '../../common/RedminePool';
+import { GroupNameEnum } from '../../configs/weeklyFinancialReport';
 import { getTargetUnits } from './getTargetUnits';
 
 type TargetUnit = {
@@ -80,6 +81,7 @@ vi.mock('../../common/fileUtils', () => ({
 }));
 vi.mock('../../configs/redmineDatabase', () => ({
   redmineDatabaseConfig: {},
+  redmineDatabaseSchema: {},
 }));
 
 describe('getTargetUnits', () => {
@@ -112,10 +114,10 @@ describe('getTargetUnits', () => {
     }));
   };
 
-  it('returns fileLink when successful', async () => {
+  it('returns fileLink when successful (default group)', async () => {
     mockRepo(true);
     writeJsonFileMock.mockResolvedValue(undefined);
-    const result = await getTargetUnits();
+    const result = await getTargetUnits(GroupNameEnum.SD_REPORT);
 
     expect(result).toEqual({ fileLink: mockFile });
     expect(writeJsonFile).toHaveBeenCalledWith(mockFile, mockUnits);
@@ -124,8 +126,10 @@ describe('getTargetUnits', () => {
   it('throws AppError when repo.getTargetUnits throws', async () => {
     mockRepo(false);
     writeJsonFileMock.mockResolvedValue(undefined);
-    await expect(getTargetUnits()).rejects.toThrow(AppError);
-    await expect(getTargetUnits()).rejects.toThrow(
+    await expect(getTargetUnits(GroupNameEnum.SD_REPORT)).rejects.toThrow(
+      AppError,
+    );
+    await expect(getTargetUnits(GroupNameEnum.SD_REPORT)).rejects.toThrow(
       'Failed to get Target Units',
     );
   });
@@ -133,8 +137,10 @@ describe('getTargetUnits', () => {
   it('throws AppError when writeJsonFile throws', async () => {
     mockRepo(true);
     writeJsonFileMock.mockRejectedValue(new Error('fail-write'));
-    await expect(getTargetUnits()).rejects.toThrow(AppError);
-    await expect(getTargetUnits()).rejects.toThrow(
+    await expect(getTargetUnits(GroupNameEnum.SD_REPORT)).rejects.toThrow(
+      AppError,
+    );
+    await expect(getTargetUnits(GroupNameEnum.SD_REPORT)).rejects.toThrow(
       'Failed to get Target Units',
     );
   });
@@ -142,7 +148,7 @@ describe('getTargetUnits', () => {
   it('always ends the Redmine pool', async () => {
     mockRepo(true);
     writeJsonFileMock.mockResolvedValue(undefined);
-    await getTargetUnits();
+    await getTargetUnits(GroupNameEnum.SD_REPORT);
     expect(endPool).toHaveBeenCalled();
   });
 });

--- a/workers/main/src/activities/weeklyFinancialReports/getTargetUnits.ts
+++ b/workers/main/src/activities/weeklyFinancialReports/getTargetUnits.ts
@@ -1,6 +1,7 @@
 import { AppError } from '../../common/errors';
 import { writeJsonFile } from '../../common/fileUtils';
 import { RedminePool } from '../../common/RedminePool';
+import { GroupName } from '../../common/types';
 import { redmineDatabaseConfig } from '../../configs/redmineDatabase';
 import { TargetUnitRepository } from '../../services/TargetUnit/TargetUnitRepository';
 
@@ -8,14 +9,16 @@ interface GetTargetUnitsResult {
   fileLink: string;
 }
 
-export const getTargetUnits = async (): Promise<GetTargetUnitsResult> => {
+export const getTargetUnits = async (
+  groupName: GroupName,
+): Promise<GetTargetUnitsResult> => {
   const redminePool = new RedminePool(redmineDatabaseConfig);
 
   try {
     const pool = redminePool.getPool();
 
     const repo = new TargetUnitRepository(pool);
-    const result = await repo.getTargetUnits();
+    const result = await repo.getTargetUnits(groupName);
     const filename = `data/weeklyFinancialReportsWorkflow/getTargetUnits/target-units-${Date.now()}.json`;
 
     await writeJsonFile(filename, result);

--- a/workers/main/src/services/TargetUnit/ITargetUnitRepository.ts
+++ b/workers/main/src/services/TargetUnit/ITargetUnitRepository.ts
@@ -1,5 +1,5 @@
-import { TargetUnit } from '../../common/types';
+import { GroupName, TargetUnit } from '../../common/types';
 
 export interface ITargetUnitRepository {
-  getTargetUnits(): Promise<TargetUnit[]>;
+  getTargetUnits(groupName: GroupName): Promise<TargetUnit[]>;
 }

--- a/workers/main/src/services/TargetUnit/TargetUnitRepository.test.ts
+++ b/workers/main/src/services/TargetUnit/TargetUnitRepository.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import { TargetUnitRepositoryError } from '../../common/errors';
 import { TargetUnit } from '../../common/types';
+import { GroupNameEnum } from '../../configs/weeklyFinancialReport';
 import { TargetUnitRepository } from './TargetUnitRepository';
 import { TargetUnitRow } from './types';
 
@@ -37,7 +38,7 @@ describe('TargetUnitRepository', () => {
     ];
 
     mockPool.query.mockResolvedValueOnce([rows]);
-    const result = await repo.getTargetUnits();
+    const result = await repo.getTargetUnits(GroupNameEnum.SD_REPORT);
 
     expect(result).toEqual<Partial<TargetUnit>[]>([
       {
@@ -55,13 +56,15 @@ describe('TargetUnitRepository', () => {
 
   it('throws TargetUnitRepositoryError if query does not return array', async () => {
     mockPool.query.mockResolvedValueOnce([null]);
-    await expect(repo.getTargetUnits()).rejects.toThrow(
+    await expect(repo.getTargetUnits(GroupNameEnum.SD_REPORT)).rejects.toThrow(
       TargetUnitRepositoryError,
     );
   });
 
   it('throws TargetUnitRepositoryError on query error', async () => {
     mockPool.query.mockRejectedValueOnce(new Error('db error'));
-    await expect(repo.getTargetUnits()).rejects.toThrowError('db error');
+    await expect(
+      repo.getTargetUnits(GroupNameEnum.SD_REPORT),
+    ).rejects.toThrowError('db error');
   });
 });

--- a/workers/main/src/services/TargetUnit/TargetUnitRepository.ts
+++ b/workers/main/src/services/TargetUnit/TargetUnitRepository.ts
@@ -3,7 +3,7 @@ import { Pool } from 'mysql2/promise';
 import { TargetUnitRepositoryError } from '../../common/errors';
 import { GroupName, TargetUnit } from '../../common/types';
 import { ITargetUnitRepository } from './ITargetUnitRepository';
-import { getTargetUnitsQuery } from './queries';
+import { TARGET_UNITS_QUERY } from './queries';
 import { TargetUnitRow } from './types';
 
 export class TargetUnitRepository implements ITargetUnitRepository {
@@ -36,7 +36,7 @@ export class TargetUnitRepository implements ITargetUnitRepository {
   async getTargetUnits(groupName: GroupName): Promise<TargetUnit[]> {
     try {
       const [rows] = await this.pool.query<TargetUnitRow[]>(
-        getTargetUnitsQuery,
+        TARGET_UNITS_QUERY,
         [groupName],
       );
 

--- a/workers/main/src/services/TargetUnit/TargetUnitRepository.ts
+++ b/workers/main/src/services/TargetUnit/TargetUnitRepository.ts
@@ -1,9 +1,9 @@
 import { Pool } from 'mysql2/promise';
 
 import { TargetUnitRepositoryError } from '../../common/errors';
-import { TargetUnit } from '../../common/types';
+import { GroupName, TargetUnit } from '../../common/types';
 import { ITargetUnitRepository } from './ITargetUnitRepository';
-import { TARGET_UNITS_QUERY } from './queries';
+import { getTargetUnitsQuery } from './queries';
 import { TargetUnitRow } from './types';
 
 export class TargetUnitRepository implements ITargetUnitRepository {
@@ -33,9 +33,12 @@ export class TargetUnitRepository implements ITargetUnitRepository {
     total_hours: Number(total_hours),
   });
 
-  async getTargetUnits(): Promise<TargetUnit[]> {
+  async getTargetUnits(groupName: GroupName): Promise<TargetUnit[]> {
     try {
-      const [rows] = await this.pool.query<TargetUnitRow[]>(TARGET_UNITS_QUERY);
+      const [rows] = await this.pool.query<TargetUnitRow[]>(
+        getTargetUnitsQuery,
+        [groupName],
+      );
 
       if (!Array.isArray(rows)) {
         throw new TargetUnitRepositoryError('Query did not return an array');

--- a/workers/main/src/services/TargetUnit/queries.ts
+++ b/workers/main/src/services/TargetUnit/queries.ts
@@ -1,41 +1,43 @@
-export const TARGET_UNITS_QUERY = `SELECT
-  group_id,
-  group_name,
-  project_id,
-  project_name,
-  user_id,
-  username,
-  DATE_FORMAT(spent_on, '%Y-%m-%d') AS spent_on,
-  SUM(total_hours) AS total_hours
-FROM (
-  SELECT
-    g.id AS group_id,
-    g.lastname AS group_name,
-    p.id AS project_id,
-    p.name AS project_name,
-    te.user_id AS user_id,
-    CONCAT(u.firstname, ' ', u.lastname) AS username,
-    te.spent_on AS spent_on,
-    te.hours AS total_hours
-  FROM users AS g
-  JOIN members AS m ON m.user_id = g.id
-  JOIN projects AS p ON p.id = m.project_id
-  JOIN time_entries te ON te.project_id = p.id
-  JOIN users AS u ON u.id = te.user_id
-  WHERE g.type = 'Group'
-    AND te.spent_on BETWEEN DATE_SUB(CURDATE(), INTERVAL WEEKDAY(CURDATE()) + 7 DAY)
-                        AND DATE_SUB(CURDATE(), INTERVAL WEEKDAY(CURDATE()) + 1 DAY)
-) t
-GROUP BY
-  group_id,
-  group_name,
-  project_id,
-  project_name,
-  user_id,
-  username,
-  spent_on
-ORDER BY
-  group_name ASC,
-  project_name ASC,
-  username ASC,
-  spent_on ASC`;
+export const getTargetUnitsQuery = `SELECT
+    group_id,
+    group_name,
+    project_id,
+    project_name,
+    user_id,
+    username,
+    DATE_FORMAT(spent_on, '%Y-%m-%d') AS spent_on,
+    SUM(total_hours) AS total_hours
+  FROM (
+    SELECT
+      g.id AS group_id,
+      g.lastname AS group_name,
+      p.id AS project_id,
+      p.name AS project_name,
+      te.user_id AS user_id,
+      CONCAT(u.firstname, ' ', u.lastname) AS username,
+      te.spent_on AS spent_on,
+      te.hours AS total_hours
+    FROM users AS g
+    JOIN custom_values as cv ON  cv.customized_id = g.id
+    JOIN members AS m ON m.user_id = g.id
+    JOIN projects AS p ON p.id = m.project_id
+    JOIN time_entries te ON te.project_id = p.id
+    JOIN users AS u ON u.id = te.user_id
+    WHERE g.type = 'Group'
+      AND cv.customized_type = 'Principal' and cv.value = ?
+      AND te.spent_on BETWEEN DATE_SUB(CURDATE(), INTERVAL WEEKDAY(CURDATE()) + 7 DAY)
+                          AND DATE_SUB(CURDATE(), INTERVAL WEEKDAY(CURDATE()) + 1 DAY)
+  ) t
+  GROUP BY
+    group_id,
+    group_name,
+    project_id,
+    project_name,
+    user_id,
+    username,
+    spent_on
+  ORDER BY
+    group_name ASC,
+    project_name ASC,
+    username ASC,
+    spent_on ASC`;

--- a/workers/main/src/services/TargetUnit/queries.ts
+++ b/workers/main/src/services/TargetUnit/queries.ts
@@ -1,4 +1,4 @@
-export const getTargetUnitsQuery = `SELECT
+export const TARGET_UNITS_QUERY = `SELECT
     group_id,
     group_name,
     project_id,

--- a/workers/main/src/workflows/weeklyFinancialReports/weeklyFinancialReports.workflow.test.ts
+++ b/workers/main/src/workflows/weeklyFinancialReports/weeklyFinancialReports.workflow.test.ts
@@ -1,22 +1,65 @@
-import { describe, expect, it, vi } from 'vitest';
+import * as workflowModule from '@temporalio/workflow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AppError } from '../../common/errors';
 import { GroupNameEnum } from '../../configs/weeklyFinancialReport';
 import { weeklyFinancialReportsWorkflow } from './weeklyFinancialReports.workflow';
 
-vi.mock('@temporalio/workflow', () => ({
-  proxyActivities: () => ({
-    getTargetUnits: vi
-      .fn()
-      .mockResolvedValue({ fileLink: 'sub-dir/mocked-link.json' }),
-  }),
-}));
+vi.mock('@temporalio/workflow', () => {
+  const getTargetUnitsMock = vi.fn();
+
+  return {
+    proxyActivities: () => ({
+      getTargetUnits: getTargetUnitsMock,
+    }),
+    __getTargetUnitsMock: () => getTargetUnitsMock,
+  };
+});
 
 describe('weeklyFinancialReportsWorkflow', () => {
-  it('returns the fileLink from getTargetUnits', async () => {
-    const result = await weeklyFinancialReportsWorkflow(
-      GroupNameEnum.ED_REPORT,
-    );
+  type WorkflowModuleWithMock = typeof workflowModule & {
+    __getTargetUnitsMock: () => ReturnType<typeof vi.fn>;
+  };
+  const getTargetUnitsMock = (
+    workflowModule as WorkflowModuleWithMock
+  ).__getTargetUnitsMock();
 
-    expect(result).toBe('sub-dir/mocked-link.json');
+  beforeEach(() => {
+    getTargetUnitsMock.mockReset();
+  });
+
+  it.each([[GroupNameEnum.SD_REPORT], [GroupNameEnum.ED_REPORT]])(
+    'returns the fileLink from getTargetUnits for group %s',
+    async (groupName: GroupNameEnum) => {
+      getTargetUnitsMock.mockResolvedValueOnce({
+        fileLink: `${groupName}-mocked-link.json`,
+      });
+      const result = await weeklyFinancialReportsWorkflow(groupName);
+
+      expect(result).toBe(`${groupName}-mocked-link.json`);
+    },
+  );
+
+  it('throws AppError for invalid group name', async () => {
+    const allowedValues = Object.values(GroupNameEnum).join('", "');
+    const expectedMessage = `Invalid groupName paramter: INVALID_GROUP. Allowed values: "${allowedValues}"`;
+
+    await expect(
+      weeklyFinancialReportsWorkflow(
+        'INVALID_GROUP' as unknown as GroupNameEnum,
+      ),
+    ).rejects.toThrow(AppError);
+    await expect(
+      weeklyFinancialReportsWorkflow(
+        'INVALID_GROUP' as unknown as GroupNameEnum,
+      ),
+    ).rejects.toThrow(expectedMessage);
+  });
+
+  it('propagates error from getTargetUnits', async () => {
+    getTargetUnitsMock.mockRejectedValueOnce(new Error('activity error'));
+    await expect(
+      weeklyFinancialReportsWorkflow(GroupNameEnum.SD_REPORT),
+    ).rejects.toThrow('activity error');
   });
 });

--- a/workers/main/src/workflows/weeklyFinancialReports/weeklyFinancialReports.workflow.ts
+++ b/workers/main/src/workflows/weeklyFinancialReports/weeklyFinancialReports.workflow.ts
@@ -18,7 +18,7 @@ export async function weeklyFinancialReportsWorkflow(
       'weeklyFinancialReportsWorkflow',
     );
   }
-  const targetUnits = await getTargetUnits();
+  const targetUnits = await getTargetUnits(groupName);
 
   return targetUnits.fileLink;
 }


### PR DESCRIPTION
- Updated the `getTargetUnits` function to accept a `groupName` parameter, enhancing its flexibility and allowing for targeted data retrieval.
- Modified the `TargetUnitRepository` and its interface to reflect the new parameter requirement.
- Adjusted related tests to ensure proper functionality with the new parameter, including validation for group names.
- Enhanced SQL query to utilize the group name for fetching relevant target units.

These changes improve the overall functionality and maintainability of the weekly financial reports workflow.