### PR TITLE
Add SlackService for posting messages to Slack (#61)

### DIFF
--- a/workers/main/src/services/SlackService.ts
+++ b/workers/main/src/services/SlackService.ts
@@ -1,0 +1,22 @@
+import { WebClient } from '@slack/web-api';
+import { slackConfig } from '../configs/slack';
+import { AppError } from '../common/errors';
+
+export class SlackService {
+  private client: WebClient;
+
+  constructor() {
+    this.client = new WebClient(slackConfig.token);
+  }
+
+  async postMessage(text: string, thread?: string) {
+    if (!slackConfig.channelId) {
+      throw new AppError('Slack channel ID not set', 'SlackServiceError');
+    }
+    return this.client.chat.postMessage({
+      channel: slackConfig.channelId,
+      text,
+      thread_ts: thread,
+    });
+  }
+} 


### PR DESCRIPTION
- Introduced `SlackService` class to facilitate posting messages to a specified Slack channel.
- Implemented error handling to throw an `AppError` if the Slack channel ID is not set, ensuring robust error reporting.
- The service utilizes the Slack Web API for message posting, enhancing integration capabilities with Slack.

These changes improve the application's ability to communicate via Slack and provide a structured approach to message handling.