### PR TITLE
feat: Add ESLint complexity and code size rules

### DIFF
--- a/workers/main/eslint.config.mjs
+++ b/workers/main/eslint.config.mjs
@@ -66,17 +66,19 @@ export default [
       // Code complexity and size rules
       'max-depth': ['error', 4],
       'max-lines': ['error', 300],
+      'max-lines-per-function': ['error', 50],
       'max-nested-callbacks': ['error', 3],
       'max-params': ['error', 5],
       'max-statements': ['error', 50],
       'complexity': ['error', 15],
     },
   },
-  // Override for test files to allow more nested callbacks
+  // Override for test files to allow more nested callbacks and longer functions
   {
     files: ['**/*.test.ts', '**/*.test.js'],
     rules: {
       'max-nested-callbacks': ['error', 4],
+      'max-lines-per-function': ['error', 150],
     },
   },
 ];


### PR DESCRIPTION
- Add max-depth rule limiting nesting to 4 levels
- Add max-lines rule limiting files to 300 lines
- Add max-nested-callbacks rule limiting to 3 nested callbacks
- Add max-params rule limiting functions to 5 parameters
- Add max-statements rule limiting functions to 50 statements
- Add complexity rule limiting cyclomatic complexity to 15
- Add test file override allowing 4 nested callbacks for test files

These rules enforce code quality standards by preventing overly complex and hard-to-maintain code structures, while allowing reasonable flexibility for test files where more nested callbacks are sometimes necessary. 