### PR TITLE
Update `.gitignore` to ignore data directory for main worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ volumes
 
 n8n-scan.sarif
 temporal-scan.sarif
+# Ignore data directory for main worker (contains runtime/generated data)
+/workers/main/data/


### PR DESCRIPTION
- Added entry to ignore the `data` directory within the `workers/main` path, which contains runtime and generated data. This change helps maintain a cleaner repository by preventing unnecessary files from being tracked.

These modifications enhance the project's file management and ensure that generated data does not clutter the version control system.