### PR TITLE
Add OAuth2Error class and corresponding tests

### DIFF
--- a/workers/main/src/common/errors/OAuth2Error.test.ts
+++ b/workers/main/src/common/errors/OAuth2Error.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { OAuth2Error } from './OAuth2Error';
+
+describe('OAuth2Error', () => {
+  it('should set the message, name, and default error code', () => {
+    const err = new OAuth2Error('test message');
+
+    expect(err.message).toBe('test message');
+    expect(err.name).toBe('OAuth2Error');
+    expect(err.code).toBe('UNKNOWN_OAUTH2_ERROR');
+  });
+
+  it('should set the message, name, and custom error code', () => {
+    const err = new OAuth2Error('test message', 'CUSTOM_ERROR');
+
+    expect(err.message).toBe('test message');
+    expect(err.name).toBe('OAuth2Error');
+    expect(err.code).toBe('CUSTOM_ERROR');
+  });
+});

--- a/workers/main/src/common/errors/OAuth2Error.ts
+++ b/workers/main/src/common/errors/OAuth2Error.ts
@@ -1,0 +1,10 @@
+import { AppError } from './AppError';
+
+export class OAuth2Error extends AppError {
+  public readonly code: string;
+
+  constructor(message: string, code: string = 'UNKNOWN_OAUTH2_ERROR') {
+    super(message, 'OAuth2Error');
+    this.code = code;
+  }
+}

--- a/workers/main/src/common/errors/index.ts
+++ b/workers/main/src/common/errors/index.ts
@@ -1,6 +1,7 @@
 export * from './AppError';
 export * from './FileUtilsError';
 export * from './FinAppRepositoryError';
+export * from './OAuth2Error';
 export * from './QuickBooksRepositoryError';
 export * from './SlackRepositoryError';
 export * from './TargetUnitRepositoryError';


### PR DESCRIPTION
- Introduced a new error class `OAuth2Error` that extends `AppError`, providing a specific error handling mechanism for OAuth2-related issues.
- Added unit tests for `OAuth2Error` to verify the correct setting of message, name, and error code.

These changes enhance error management in the application by allowing for more granular handling of OAuth2 errors.