### PR TITLE
Add security configurations and authentication environment variables …

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,10 @@ services:
       - N8N_BLOCKED_NODES=n8n-nodes-base.executeCommand,n8n-nodes-base.ssh
       - N8N_DEFAULT_BINARY_DATA_MODE=filesystem
       - N8N_BINARY_DATA_STORAGE_PATH=/data/n8n/binaryData
+      # Allowlist specific safe environment variables for node access
+      - N8N_ENV_ACCESS_ALLOWED=SEMBLY_USER,SEMBLY_PASS
+      - SEMBLY_USER=${SEMBLY_USER:?SEMBLY_USER is required}
+      - SEMBLY_PASS=${SEMBLY_PASS:?SEMBLY_PASS is required}
   postgresql: !reset null
 
   temporal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       - DB_POSTGRESDB_DATABASE=${POSTGRES_DB_N8N:-n8n}
       - DB_POSTGRESDB_USER=${POSTGRES_USER_N8N:-n8n}
       - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD_N8N:-n8n_password}
+      # Block $env access in nodes for security (default: true)
+      - N8N_BLOCK_ENV_ACCESS_IN_NODE=true
+      - SEMBLY_USER=${SEMBLY_USER:-sembly_user}
+      - SEMBLY_PASS=${SEMBLY_PASS:-sembly_pass}
       - N8N_LOG_LEVEL=debug
       - N8N_LOG_OUTPUT=console
       - TZ=${TZ:-America/New_York}


### PR DESCRIPTION
…to Docker Compose files

- Add N8N_BLOCK_ENV_ACCESS_IN_NODE=true to docker-compose.yml for enhanced security
- Add N8N_ENV_ACCESS_ALLOWED with ASSEMBLY_USER and ASSEMBLY_PASS to docker-compose.prod.yml
- Add ASSEMBLY_USER and ASSEMBLY_PASS environment variables to both compose files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enforced required credentials at startup for the automation service in production deployments.
  - Provided sensible default credentials for local setups while maintaining strict checks in production.
  - Restricted in-app access to environment variables to reduce exposure of sensitive data.
  - No impact to other services or runtime behavior beyond stricter credential validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->