### PR TITLE
Add ffmpeg package to n8n Docker image for media processing

### DIFF
--- a/Dockerfile.n8n
+++ b/Dockerfile.n8n
@@ -7,10 +7,10 @@ ARG SHOWDOWN_VERSION=^2.1.0
 ARG SLACKIFY_MARKDOWN_VERSION=^4.5.0
 ARG TIKTOKEN_VERSION=^1.0.21
 
-# Install git for backup script and other packages + install external packages in one layer
+# Install git (backup scripts) and ffmpeg (media processing) + external npm packages in one layer
 USER root
 RUN set -eux; \
-  apk add --no-cache git=2.49.1-r0 ffmpeg && \
+  apk add --no-cache git=2.49.1-r0 ffmpeg=6.1.2-r2 && \
   npm install -g --no-audit --no-fund --ignore-scripts \
     --legacy-peer-deps --no-workspaces \
     --unsafe-perm \

--- a/Dockerfile.n8n
+++ b/Dockerfile.n8n
@@ -10,7 +10,7 @@ ARG TIKTOKEN_VERSION=^1.0.21
 # Install git for backup script and other packages + install external packages in one layer
 USER root
 RUN set -eux; \
-  apk add --no-cache git=2.49.1-r0 && \
+  apk add --no-cache git=2.49.1-r0 ffmpeg && \
   npm install -g --no-audit --no-fund --ignore-scripts \
     --legacy-peer-deps --no-workspaces \
     --unsafe-perm \


### PR DESCRIPTION
Click Up Task: https://app.clickup.com/t/86c7xzdpc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a system-level media processing tool to the runtime image to enable improved audio/video/image handling; no other runtime behavior or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Usage in Production

While `N8N_BLOCKED_NODES` blocks the Execute Command node in production,
ffmpeg is accessible through:
- **Community FFmpeg nodes** (e.g., `n8n-nodes-mediafx`, `@raisaroj/n8n-nodes-ffmpeg`)
  installed via Settings > Community Nodes in the n8n UI
- **Code/Function nodes** that invoke ffmpeg programmatically

The ffmpeg binary must be present at the system level for any of these
integration methods to work.